### PR TITLE
Upgrade Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     minitest (5.11.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.5.11)
+    nokogiri (1.8.2)
     octokit (4.9.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.1)


### PR DESCRIPTION
This will get rid of the Github scary banner about security
vulnerabilities.  They shouldn't matter since they're only being loaded
to run the tests, but also it shouldn't hurt anything to upgrade this.